### PR TITLE
Feature docker compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,21 @@ This can also be done by using the Dockerfile for a more reliable build environm
 docker-compose -f docker-compose.stage.yaml up
 ```
 
+### Local
+
+Builds that point to local GraphDB can be achieved with
+
+
+```
+ng build --configuration=local
+```
+
+This can also be done by using the Dockerfile for a more reliable build environment with
+
+```
+docker-compose -f docker-compose.local.yaml up
+```
+
 ## Developing
 
 The standard Git Flow: create a feature branch off of the `develop` branch and make pull requests into it. For full releases, merge from the `develop` branch into `main`.

--- a/README.md
+++ b/README.md
@@ -40,7 +40,14 @@ Production deployments should deploy the application by building and serving the
 To build the node explorer,
 
 ```
-ng build --configuration=prod
+ng build --configuration=production
+```
+
+This can also be done by using the Dockerfile for a more reliable build environment with
+
+```
+docker-compose -f docker-compose.prod.yaml up
+
 ```
 
 ### Staging
@@ -49,6 +56,12 @@ Staging builds are done similarly to production with
 
 ```
 ng build --configuration=stage
+```
+
+This can also be done by using the Dockerfile for a more reliable build environment with
+
+```
+docker-compose -f docker-compose.stage.yaml up
 ```
 
 ## Developing

--- a/node-browser/Dockerfile
+++ b/node-browser/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:16.0.0-bullseye-slim
+FROM amd64/node:lts-buster-slim
 
 RUN mkdir /app
 WORKDIR /app

--- a/node-browser/Dockerfile
+++ b/node-browser/Dockerfile
@@ -1,0 +1,10 @@
+FROM node:16.0.0-bullseye-slim
+
+RUN mkdir /app
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm i
+RUN npm install -g @angular/cli
+
+COPY . .

--- a/node-browser/docker-compose.local.yaml
+++ b/node-browser/docker-compose.local.yaml
@@ -1,0 +1,6 @@
+services:
+  node-explorer:
+    build: '.'
+    volumes:
+      - ./dist/:/app/dist/
+    entrypoint: ["ng","build","--configuration=local"]

--- a/node-browser/docker-compose.stage.yaml
+++ b/node-browser/docker-compose.stage.yaml
@@ -1,0 +1,6 @@
+services:
+  node-explorer:
+    build: '.'
+    volumes:
+      - ./dist/:/app/dist/
+    entrypoint: ["ng","build","--configuration=stage"]

--- a/node-browser/docker-compose.yaml
+++ b/node-browser/docker-compose.yaml
@@ -1,0 +1,6 @@
+services:
+  node-explorer:
+    build: '.'
+    volumes:
+      - ./dist/:/app/dist/
+    entrypoint: ["ng","build","--configuration=production"]


### PR DESCRIPTION
Change that adds a dockerized build, this way-the node version is always consistent and avoids local system clashes. It supports three builds:

- production
- stage
- local

Each corresponding to a json struct [here](https://github.com/KnowWhereGraph/node-browser/blob/main/node-browser/angular.json#L42)

The container goes away once the build is complete, and the files are left in the local volume that's mounted to the container's `dist/` folder.